### PR TITLE
Bundle lit library into the card for fully offline operation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "device-pulse-table",
       "version": "1.0.0",
       "dependencies": {
-        "dotenv": "^17.4.2"
+        "dotenv": "^17.4.2",
+        "lit": "3.1.2"
       },
       "devDependencies": {
         "esbuild": "^0.24.0"
@@ -439,6 +440,27 @@
         "node": ">=18"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.6.0.tgz",
+      "integrity": "sha512-VHb0ALPMTlgKjM6yIxxoQNnpKyUKLD04VzeQdsiXkMqkvYlAHxq9glGLmgbb889/1GsohSOAjvQYoiBppXFqrQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
     "node_modules/dotenv": {
       "version": "17.4.2",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
@@ -489,6 +511,37 @@
         "@esbuild/win32-arm64": "0.24.2",
         "@esbuild/win32-ia32": "0.24.2",
         "@esbuild/win32-x64": "0.24.2"
+      }
+    },
+    "node_modules/lit": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.1.2.tgz",
+      "integrity": "sha512-VZx5iAyMtX7CV4K8iTLdCkMaYZ7ipjJZ0JcSdJ0zIdGxxyurjIn7yuuSxNBD7QmjvcNJwr0JS4cAdAtsy7gZ6w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.0.4",
+        "lit-element": "^4.0.4",
+        "lit-html": "^3.1.2"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-html": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.3.tgz",
+      "integrity": "sha512-el8M6jK2o3RXBnrSHX3ZKrsN8zEV63pSExTO1wYJz7QndGYZ8353e2a5PPX+qHe2aGayfnchQmkAojaWAREOIA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "esbuild": "^0.24.0"
   },
   "dependencies": {
-    "dotenv": "^17.4.2"
+    "dotenv": "^17.4.2",
+    "lit": "3.1.2"
   }
 }

--- a/src/device-pulse-table-card-style.js
+++ b/src/device-pulse-table-card-style.js
@@ -1,4 +1,4 @@
-import { css } from "https://unpkg.com/lit@3.1.2/index.js?module";
+import { css } from "lit";
 
 export const cardStyles = css`
     :host {

--- a/src/device-pulse-table-card.js
+++ b/src/device-pulse-table-card.js
@@ -1,5 +1,5 @@
-import { LitElement, html, css } from "https://unpkg.com/lit@3.1.2/index.js?module";
-import { when } from "https://unpkg.com/lit@3.1.2/directives/when.js?module";
+import { LitElement, html, css } from "lit";
+import { when } from "lit/directives/when.js";
 import { cardStyles } from './device-pulse-table-card-style.js';
 
 const CARD_VERSION = "1.1.0";


### PR DESCRIPTION
## Summary
- Replace CDN (`https://unpkg.com/lit@3.1.2/...`) and `/local/lit/...` imports with the `lit` package dependency so the card works **fully offline**, without any access to unpkg.com
- Add `lit@3.1.2` as a dependency in `package.json`
- The esbuild bundle now inlines lit and the card styles into a single self-contained `dist/device-pulse-table-card.js`

## Why
The card previously loaded lit from unpkg.com at runtime. When Home Assistant has no access to the CDN, the card fails to render. With lit bundled, only the single card file needs to be copied to `www/` — no external resources required.

## Testing
- `npm install && npm run build` succeeds
- Resulting `dist/device-pulse-table-card.js` (32.8K) contains zero references to unpkg.com or /local/